### PR TITLE
feat: djangoness

### DIFF
--- a/djapy/core/dec/base_dec.py
+++ b/djapy/core/dec/base_dec.py
@@ -112,13 +112,11 @@ class BaseDjapifyDecorator:
       if payload := is_payload_type(annotation):
          content_type = payload.cvar_c_type
          annotation = payload.unquery_type
-         print('unquerytype', annotation)
       else:
          content_type = getattr(annotation, 'cvar_c_type', None)
 
       # Route parameter to appropriate schema based on content type
       if content_type == "application/x-www-form-urlencoded":
-         print(annotation, default)
          forms[param.name] = (annotation, default)
       elif content_type == "application/json":
          data[param.name] = (annotation, default)

--- a/djapy/core/dec/base_dec.py
+++ b/djapy/core/dec/base_dec.py
@@ -17,7 +17,7 @@ from djapy.core.parser import get_response_schema_dict
 from djapy.core.response import create_json_from_validation_error
 from djapy.core.type_check import (
    is_param_query_type,
-   is_data_type, is_payload_type
+   is_data_type
 )
 from djapy.core.labels import (
    REQUEST_INPUT_DATA_SCHEMA_NAME,
@@ -26,6 +26,7 @@ from djapy.core.labels import (
    DJAPY_AUTH
 )
 from djapy.core.view_func import WrappedViewT, ViewFuncT
+from djapy.schema.handle import is_payload_type
 from djapy.schema.schema import Schema, Form, QueryMapperSchema
 
 ERROR_HANDLER_MODULE = "djapy_ext.errorhandler"
@@ -76,12 +77,9 @@ class BaseDjapifyDecorator:
    @staticmethod
    def _get_tuple(param: inspect.Parameter, annotation: Any = None) -> tuple:
       """Get tuple for pydantic model creation"""
-      annotation = annotation or param.annotation
-      default = ... if param.default is inspect.Parameter.empty else param.default
-
-      if payload := is_payload_type(annotation):
-         return payload.unquery_type, default, payload.cvar_c_type
-      return annotation, default, None
+      if annotation is None:
+         annotation = param.annotation
+      return (annotation, ...) if param.default is inspect.Parameter.empty else (annotation, param.default)
 
    def _add_query(self, param: inspect.Parameter, queries: Dict) -> None:
       """Add query parameter to schema dictionary"""
@@ -92,18 +90,40 @@ class BaseDjapifyDecorator:
          )
       queries[param.name] = self._get_tuple(param)
 
-   def _add_content(self, param: inspect.Parameter, forms: Dict,
-                    data: Dict, data_type: Any) -> None:
-      """Add content type to appropriate schema"""
-      annotation, default, cvar_c_type = self._get_tuple(param, data_type)
+   def _add_content(
+     self,
+     param: inspect.Parameter,
+     forms: Dict,
+     data: Dict,
+     data_type: Any
+   ) -> None:
+      """
+      Add content type to appropriate schema based on parameter annotation.
 
-      if cvar_c_type:
-         if cvar_c_type == "application/x-www-form-urlencoded":
-            forms[param.name] = (annotation, default)
-         elif cvar_c_type == "application/json":
-            data[param.name] = (annotation, default)
+      Args:
+          param: The parameter to analyze
+          forms: Dictionary to store form-encoded parameters
+          data: Dictionary to store JSON parameters
+          data_type: The type annotation for the parameter
+      """
+      annotation, default = self._get_tuple(param, data_type)
+
+      # Determine content type from payload or annotation
+      if payload := is_payload_type(annotation):
+         content_type = payload.cvar_c_type
+         annotation = payload.unquery_type
+         print('unquerytype', annotation)
       else:
+         content_type = getattr(annotation, 'cvar_c_type', None)
+
+      # Route parameter to appropriate schema based on content type
+      if content_type == "application/x-www-form-urlencoded":
+         print(annotation, default)
+         forms[param.name] = (annotation, default)
+      elif content_type == "application/json":
          data[param.name] = (annotation, default)
+      else:
+         data[param.name] = (annotation, default)  # Default to JSON
 
    def _prepare(self, w: WrappedViewT) -> None:
       """Prepare view function attributes"""

--- a/djapy/core/mid.py
+++ b/djapy/core/mid.py
@@ -16,7 +16,7 @@ class UHandleErrorMiddleware:
    def __call__(self, request):
       response = self.get_response(request)
       user_agent = request.headers.get('User-Agent')
-      is_browser = 'Mozilla/' in user_agent
+      is_browser = 'Mozilla/' in user_agent if user_agent else False
       if response.status_code >= 400 and response.headers['Content-Type'] != 'application/json' and not is_browser:
          error_response = {
             "message": "An error occurred while processing your request.",

--- a/djapy/core/type_check.py
+++ b/djapy/core/type_check.py
@@ -121,6 +121,9 @@ def is_data_type(param: Parameter):
    """
    if is_django_type(param):
       return None
-   if isinstance(param.annotation, djapy.schema.handle.Payload):
-      return param.annotation.unquery_type
    return param.annotation
+
+
+def is_payload_type(param: Parameter) -> djapy.schema.handle.Payload | None:
+   if isinstance(param.annotation, djapy.schema.handle.Payload):
+      return param.annotation

--- a/djapy/core/type_check.py
+++ b/djapy/core/type_check.py
@@ -6,8 +6,6 @@ from typing import Union, get_args, get_origin, Literal, List, Optional, Annotat
 from django.http import HttpResponseBase
 from pydantic import BaseModel
 
-import djapy.schema.handle
-
 BASIC_TYPES = {
    "str": "string",
    "int": "integer",
@@ -122,8 +120,3 @@ def is_data_type(param: Parameter):
    if is_django_type(param):
       return None
    return param.annotation
-
-
-def is_payload_type(param: Parameter) -> djapy.schema.handle.Payload | None:
-   if isinstance(param.annotation, djapy.schema.handle.Payload):
-      return param.annotation

--- a/djapy/schema/__init__.py
+++ b/djapy/schema/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['Schema', 'Form', 'QueryList', 'Outsource', 'payload', 'uni_schema']
+__all__ = ['Schema', 'Form', 'QueryList', 'Outsource', 'as_json', 'as_form', 'uni_schema']
 
-from djapy.schema.handle import payload, uni_schema
+from djapy.schema.handle import as_json, as_form, uni_schema
 from djapy.schema.schema import Schema, Outsource, Form, QueryList

--- a/djapy/schema/handle.py
+++ b/djapy/schema/handle.py
@@ -1,4 +1,4 @@
-__all__ = ['payload', 'uni_schema', 'status_codes']
+__all__ = ['payload', 'form', 'uni_schema', 'status_codes']
 
 from http.client import responses
 from typing import Type, TypedDict, Literal

--- a/djapy/schema/handle.py
+++ b/djapy/schema/handle.py
@@ -1,4 +1,4 @@
-__all__ = ['payload', 'form', 'uni_schema', 'status_codes']
+__all__ = ['as_json', 'as_form', 'uni_schema', 'status_codes']
 
 from http.client import responses
 from typing import Type, TypedDict, Literal
@@ -61,8 +61,8 @@ class Payload:
       return self
 
 
-payload = Payload()
-form = Payload("application/x-www-form-urlencoded")
+as_json = Payload()
+as_form = Payload("application/x-www-form-urlencoded")
 
 uni_schema = ReSchema()  # uni_schema is short for unified schema
 status_codes = StatusCodes()

--- a/djapy/schema/handle.py
+++ b/djapy/schema/handle.py
@@ -1,6 +1,7 @@
-__all__ = ['as_json', 'as_form', 'uni_schema', 'status_codes']
+__all__ = ['as_json', 'as_form', 'uni_schema', 'status_codes', 'is_payload_type']
 
 from http.client import responses
+from inspect import Parameter
 from typing import Type, TypedDict, Literal
 
 from .schema import Schema
@@ -59,6 +60,11 @@ class Payload:
       """
       self.unquery_type = type_
       return self
+
+
+def is_payload_type(param: Parameter) -> Payload | None:
+   if param and isinstance(param, Payload):
+      return param
 
 
 as_json = Payload()

--- a/djapy/schema/handle.py
+++ b/djapy/schema/handle.py
@@ -1,7 +1,7 @@
 __all__ = ['payload', 'uni_schema', 'status_codes']
 
 from http.client import responses
-from typing import Type, TypedDict
+from typing import Type, TypedDict, Literal
 
 from .schema import Schema
 from djapy.core.typing_utils import G_TYPE
@@ -48,7 +48,10 @@ class ReSchema:
 
 class Payload:
    unquery_type: G_TYPE | None = None
-   cvar_c_type = 'application/json'
+
+   def __init__(self,
+                cvar_c_type: Literal["application/json", "application/x-www-form-urlencoded"] = "application/json"):
+      self.cvar_c_type = cvar_c_type
 
    def __call__(self, type_: G_TYPE) -> G_TYPE:
       """
@@ -59,5 +62,7 @@ class Payload:
 
 
 payload = Payload()
+form = Payload("application/x-www-form-urlencoded")
+
 uni_schema = ReSchema()  # uni_schema is short for unified schema
 status_codes = StatusCodes()

--- a/djapy/schema/handle.py
+++ b/djapy/schema/handle.py
@@ -48,6 +48,7 @@ class ReSchema:
 
 class Payload:
    unquery_type: G_TYPE | None = None
+   cvar_c_type = 'application/json'
 
    def __call__(self, type_: G_TYPE) -> G_TYPE:
       """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
    name="djapy",
-   version="0.2.0",
+   version="0.2.1",
    description="Fast, zero-boilerplate Django REST API framework with pure Python typing!",
    long_description=long_description,
    long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR introduces several important improvements to request payload handling and error responses in djapy:

### Content Type Handling Enhancements
- Refactored the payload handling system to provide more explicit content type control
- Introduced new decorators `as_json` and `as_form` to replace the generic `payload` decorator, making content type intentions clearer in the code
- `as_form` decorator now provides explicit form-encoded payload handling for view parameters, allowing type validation while maintaining form-data compatibility

### Real-world Usage Example
The `as_form` decorator can be used to type-validate form-encoded parameters while maintaining compatibility with form submissions:

```python
@async_djapify(method="POST", auth=SessionAuth)
async def depth_perception_view(request, inp_: as_form(HttpUrl)) -> AnalysisResponse:
    # inp_ is guaranteed to be a valid URL from form-encoded data
    analyzer = CityPagesDepthAnalyzer(str(inp_))
    ...

@async_djapify(method="POST", auth=SessionAuth)
async def prompt_analysis_view(request, inp_: as_form(constr(min_length=12))) -> AnalysisResponse:
    # inp_ is guaranteed to be a string with minimum length of 12 characters
    basic_ai_reports = await generate_seo_analysis(inp_)
    ...
```

### Migration Guide
For existing code using the `payload` decorator, replace it as follows:

```python
# Old
@djapy
def myview(title: payload(str)):
    ...

# New - for form-encoded payloads
@djapy
def myview(title: as_form(str)):
    ...

# New - for JSON payloads
@djapy
def myview(title: as_json(str)):
    ...
```

### Other Improvements
- Fixed potential `None` access in middleware when handling User-Agent header by adding proper null check
- Removed circular import dependency between `djapy.schema.handle` and `djapy.core.type_check`
- Updated `__all__` exports to reflect new decorator names
- Improved code organization and type hints
- Added proper documentation for content type handling functions

### Version Bump
- Incremented version from 0.2.0 to 0.2.1
