### PR TITLE
Add CI/CD, test suite (122 tests, 84% coverage), and fix 5 bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: uv tool install ruff
+      - run: ruff check src/
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12", "3.13"]
+        django-version: ["4.2", "5.0", "5.1"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          uv sync --extra dev
+          uv pip install "Django~=${{ matrix.django-version }}.0"
+      - name: Run tests
+        run: uv run pytest tests/ -v --tb=short --cov=src/djapy --cov-report=xml
+      - name: Upload coverage
+        if: matrix.python-version == '3.13' && matrix.django-version == '5.1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: uv sync --extra dev
+      - name: Run tests with coverage
+        run: uv run pytest tests/ --cov=src/djapy --cov-report=term-missing --cov-fail-under=60

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,17 +10,28 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Framework :: Django",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Operating System :: OS Independent"
+    "Operating System :: OS Independent",
 ]
 dependencies = [
-    "Django",
+    "Django>=4.2,<5.2",
     "pydantic>=2.0",
+    "asgiref>=3.7.0",
 ]
 
 [project.optional-dependencies]
 performance = [
-    "orjson>=3.9.0",  # Fast JSON serialization (3-5x faster than standard json)
+    "orjson>=3.9.0",
+]
+dev = [
+    "pytest>=8.0",
+    "pytest-django>=4.8",
+    "pytest-asyncio>=0.23",
+    "pytest-cov>=5.0",
 ]
 
 [build-system]
@@ -28,14 +39,11 @@ requires = ["uv_build>=0.8.6,<0.9.0"]
 build-backend = "uv_build"
 
 [project.urls]
-Homepage = "https://example.com"
+Homepage = "https://github.com/Bishwas-py/djapy"
 Documentation = "https://djapy-docs.pages.dev/"
 Repository = "https://github.com/Bishwas-py/djapy"
 
-
-
-
-
-
-  
-
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "tests.settings"
+pythonpath = ["src", "."]
+asyncio_mode = "auto"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-line-length = 10000
+line-length = 320
 
 
 [format]

--- a/src/djapy/core/auth/dec.py
+++ b/src/djapy/core/auth/dec.py
@@ -36,7 +36,8 @@ def djapy_auth(auth: Type[BaseAuthMechanism] | BaseAuthMechanism | None = None,
          wrapped.djapy_auth = auth(permissions)
       else:
          wrapped.djapy_auth = auth
-      wrapped.djapy_auth.set_message_response(msg)
+      if msg is not None:
+         wrapped.djapy_auth.set_message_response(msg)
 
       return wrapped
 

--- a/src/djapy/core/dec/base_dec.py
+++ b/src/djapy/core/dec/base_dec.py
@@ -73,6 +73,9 @@ class BaseDjapifyDecorator:
          return None
       if r := w.djapy_auth.authenticate(request, *args, **kwargs):
          return JsonResponse(r[1], status=r[0])
+      if w.djapy_auth.permissions:
+         if r := w.djapy_auth.authorize(request, *args, **kwargs):
+            return JsonResponse(r[1], status=r[0])
 
    @staticmethod
    def _get_tuple(param: inspect.Parameter, annotation: Any = None) -> tuple:

--- a/src/djapy/core/parser.py
+++ b/src/djapy/core/parser.py
@@ -87,7 +87,10 @@ class RequestParser(BaseParser):
       body_data = {}
       if not self.schemas["data"].is_empty():
          body_str = self._get_body()
-         if body_str and body_str.strip():  # Check for non-empty
+         if not body_str or not body_str.strip():
+            # Empty body but schema expects data — validate empty dict to get proper error
+            body_data = self._validate_schema(self.schemas["data"], {})
+         elif body_str and body_str.strip():  # Check for non-empty
             try:
                # Fast path: use model_validate_json for better performance
                body_bytes = body_str.encode('utf-8')

--- a/src/djapy/schema/schema.py
+++ b/src/djapy/schema/schema.py
@@ -126,7 +126,7 @@ json_modal_schema = create_model(
 def get_json_dict(to_jsonify_text: str):
    return json_modal_schema.model_validate({
       JSON_BODY_PARSE_NAME: to_jsonify_text
-   }).dict().get(JSON_BODY_PARSE_NAME)
+   }).model_dump().get(JSON_BODY_PARSE_NAME)
 
 
 class QueryMapperSchema(Schema):
@@ -154,7 +154,7 @@ class Form(QueryMapperSchema):
    cvar_c_type = "application/x-www-form-urlencoded"
 
 
-class Outsource(BaseModel):
+class Outsource(Schema):
    """
    Allows the model to have a source object, info object and context object.
    Specially useful for validation and checking on @computed_fields.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client, RequestFactory
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="testuser", password="testpass123")
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_superuser(
+        username="admin", password="adminpass123", email="admin@test.com"
+    )
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def auth_client(user):
+    c = Client()
+    c.login(username="testuser", password="testpass123")
+    return c
+
+
+@pytest.fixture
+def admin_client(admin_user):
+    c = Client()
+    c.login(username="admin", password="adminpass123")
+    return c
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,29 @@
+SECRET_KEY = "test-secret-key-not-for-production"
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "django.contrib.sessions",
+    "tests.testapp",
+]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+ROOT_URLCONF = "tests.testapp.urls"
+
+MIDDLEWARE = [
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+]
+
+USE_TZ = True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,88 @@
+import json
+import pytest
+from django.test import Client
+from django.contrib.auth.models import User, Permission
+from django.contrib.contenttypes.models import ContentType
+
+from djapy.core.auth.auth import BaseAuthMechanism, SessionAuth
+
+
+class TestSessionAuthUnit:
+    def test_unauthenticated_returns_403(self, rf):
+        auth = SessionAuth()
+        request = rf.get("/")
+        from django.contrib.auth.models import AnonymousUser
+        request.user = AnonymousUser()
+        result = auth.authenticate(request)
+        assert result == (403, {"message": "Unauthorized"})
+
+    def test_authenticated_returns_none(self, rf, user):
+        auth = SessionAuth()
+        request = rf.get("/")
+        request.user = user
+        result = auth.authenticate(request)
+        assert result is None
+
+    def test_schema_returns_security_schemes(self):
+        auth = SessionAuth()
+        schema = auth.schema()
+        assert "SessionAuth" in schema
+        assert "CSRFTokenAuth" in schema
+        assert schema["SessionAuth"]["type"] == "apiKey"
+
+    def test_app_schema(self):
+        auth = SessionAuth()
+        app_schema = auth.app_schema()
+        assert "SessionAuth" in app_schema
+
+
+class TestBaseAuthMechanism:
+    def test_default_message(self):
+        auth = BaseAuthMechanism()
+        assert auth.message_response == {"message": "Unauthorized"}
+
+    def test_custom_message(self):
+        auth = BaseAuthMechanism(message_response={"message": "Go away"})
+        assert auth.message_response == {"message": "Go away"}
+
+    def test_set_message_response(self):
+        auth = BaseAuthMechanism()
+        auth.set_message_response({"message": "Custom"})
+        assert auth.message_response == {"message": "Custom"}
+
+    def test_authenticate_returns_none_by_default(self, rf):
+        auth = BaseAuthMechanism()
+        request = rf.get("/")
+        assert auth.authenticate(request) is None
+
+
+class TestAuthViews:
+    def test_protected_view_unauthenticated(self, client, db):
+        response = client.get("/items/protected/")
+        assert response.status_code == 403
+        data = json.loads(response.content)
+        assert data["message"] == "Unauthorized"
+
+    def test_protected_view_authenticated(self, auth_client, db):
+        response = auth_client.get("/items/protected/")
+        assert response.status_code == 200
+
+    def test_public_view_no_auth_needed(self, client, db):
+        response = client.get("/items/public/")
+        assert response.status_code == 200
+
+    def test_permission_view_without_perm(self, auth_client, db):
+        response = auth_client.get("/items/permission/")
+        assert response.status_code == 403
+
+    def test_permission_view_with_perm(self, user, db):
+        perm = Permission.objects.get(
+            codename="add_item",
+            content_type__app_label="testapp",
+        )
+        user.user_permissions.add(perm)
+        user.save()
+        c = Client()
+        c.login(username="testuser", password="testpass123")
+        response = c.get("/items/permission/")
+        assert response.status_code == 200

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,131 @@
+import json
+import pytest
+from django.test import Client
+
+from tests.testapp.models import Item
+
+
+@pytest.fixture
+def items(db):
+    return [
+        Item.objects.create(title="Item A", price=10.00),
+        Item.objects.create(title="Item B", price=20.00),
+        Item.objects.create(title="Item C", price=30.00, is_active=False),
+    ]
+
+
+class TestDjapifySync:
+    def test_list_items_returns_200(self, client, items):
+        response = client.get("/items/")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert len(data) == 3
+
+    def test_list_items_json_content_type(self, client, items):
+        response = client.get("/items/")
+        assert "application/json" in response["Content-Type"]
+
+    def test_create_item_with_json_body(self, client, db):
+        response = client.post(
+            "/items/create/",
+            data=json.dumps({"title": "New Item", "price": 15.50}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data["title"] == "New Item"
+        assert Item.objects.filter(title="New Item").exists()
+
+    def test_create_item_validation_error(self, client, db):
+        response = client.post(
+            "/items/create/",
+            data=json.dumps({"title": "Bad", "price": -5}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_get_item_by_pk(self, client, items):
+        item = items[0]
+        response = client.get(f"/items/{item.pk}/")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data["title"] == "Item A"
+        assert data["id"] == item.pk
+
+    def test_get_item_not_found(self, client, db):
+        response = client.get("/items/99999/")
+        assert response.status_code == 404
+        data = json.loads(response.content)
+        assert data["alias"] == "not_found"
+
+    def test_query_params(self, client, items):
+        response = client.get("/items/search/?q=Item A&active=true")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert len(data) == 1
+        assert data[0]["title"] == "Item A"
+
+    def test_query_params_filter_inactive(self, client, items):
+        response = client.get("/items/search/?q=Item C&active=false")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert len(data) == 1
+
+
+class TestMethodRestriction:
+    def test_post_only_rejects_get(self, client, db):
+        response = client.get("/items/create/")
+        assert response.status_code == 405
+
+    def test_multi_method_allows_get(self, client, items):
+        response = client.get("/items/multi-method/")
+        assert response.status_code == 200
+
+    def test_multi_method_allows_post(self, client, items):
+        response = client.post("/items/multi-method/", content_type="application/json")
+        assert response.status_code == 200
+
+    def test_multi_method_rejects_put(self, client, items):
+        response = client.put("/items/multi-method/", content_type="application/json")
+        assert response.status_code == 405
+
+
+class TestJsonResponsePassthrough:
+    def test_returns_custom_json(self, client, db):
+        response = client.get("/items/json-response/")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data == {"custom": "response"}
+
+
+class TestStatusCodes:
+    def test_returns_200(self, client, items):
+        response = client.post(
+            "/items/status-code/?fail=false",
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+    def test_returns_400(self, client, items):
+        response = client.post(
+            "/items/status-code/?fail=true",
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = json.loads(response.content)
+        assert data["alias"] == "bad_request"
+
+
+class TestAsyncDjapify:
+    def test_async_list_items(self, client, items):
+        response = client.get("/items/async/")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert isinstance(data, list)
+
+    def test_async_rejects_non_coroutine(self):
+        from djapy import async_djapify
+        with pytest.raises(ValueError, match="must be async"):
+            @async_djapify
+            def not_async(request):
+                pass

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,47 @@
+import json
+import pytest
+from django.test import Client
+
+from tests.testapp.models import Item
+
+
+class TestValidationErrors:
+    def test_missing_required_field(self, client, db):
+        response = client.post(
+            "/items/create/",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = json.loads(response.content)
+        assert data["type"] == "validation_error"
+        assert data["error_count"] >= 1
+
+    def test_wrong_type(self, client, db):
+        response = client.post(
+            "/items/create/",
+            data=json.dumps({"title": "Test", "price": "not_a_number"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_constraint_violation(self, client, db):
+        """Price must be > 0 per the schema Field(gt=0)."""
+        response = client.post(
+            "/items/create/",
+            data=json.dumps({"title": "Test", "price": 0}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+
+class TestMethodNotAllowed:
+    def test_get_on_post_only(self, client, db):
+        response = client.get("/items/create/")
+        assert response.status_code == 405
+        data = json.loads(response.content)
+        assert data["alias"] == "method_not_allowed"
+
+    def test_delete_on_get_only(self, client, db):
+        response = client.delete("/items/")
+        assert response.status_code == 405

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,66 @@
+import json
+from django.http import HttpResponse, JsonResponse
+from django.test import RequestFactory
+
+from djapy.core.mid import UHandleErrorMiddleware
+
+
+def _make_middleware(response):
+    return UHandleErrorMiddleware(lambda request: response)
+
+
+class TestUHandleErrorMiddleware:
+    def setup_method(self):
+        self.rf = RequestFactory()
+
+    def test_passes_through_200(self):
+        response = JsonResponse({"ok": True})
+        mw = _make_middleware(response)
+        result = mw(self.rf.get("/"))
+        assert result.status_code == 200
+
+    def test_converts_html_error_to_json_for_api(self):
+        html_response = HttpResponse("<h1>Not Found</h1>", status=404, content_type="text/html")
+        html_response.reason_phrase = "Not Found"
+        mw = _make_middleware(html_response)
+
+        request = self.rf.get("/", HTTP_USER_AGENT="curl/7.68.0")
+        result = mw(request)
+
+        assert result.status_code == 404
+        data = json.loads(result.content)
+        assert data["reason"] == "Not Found"
+        assert data["alias"] == "server_error"
+
+    def test_keeps_html_for_browser(self):
+        html_response = HttpResponse("<h1>Not Found</h1>", status=404, content_type="text/html")
+        mw = _make_middleware(html_response)
+
+        request = self.rf.get("/", HTTP_USER_AGENT="Mozilla/5.0 (Windows)")
+        result = mw(request)
+
+        assert result.status_code == 404
+        assert b"<h1>" in result.content
+
+    def test_passes_through_json_errors(self):
+        json_response = JsonResponse({"error": "bad"}, status=400)
+        mw = _make_middleware(json_response)
+
+        request = self.rf.get("/", HTTP_USER_AGENT="curl/7.68.0")
+        result = mw(request)
+
+        assert result.status_code == 400
+        data = json.loads(result.content)
+        assert data == {"error": "bad"}
+
+    def test_handles_500(self):
+        html_response = HttpResponse("Server Error", status=500, content_type="text/html")
+        html_response.reason_phrase = "Internal Server Error"
+        mw = _make_middleware(html_response)
+
+        request = self.rf.get("/", HTTP_USER_AGENT="python-requests/2.28")
+        result = mw(request)
+
+        assert result.status_code == 500
+        data = json.loads(result.content)
+        assert data["reason"] == "Internal Server Error"

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,60 @@
+import pytest
+from django.test import RequestFactory
+
+from djapy.openapi import openapi
+
+
+class TestOpenAPIGeneration:
+    def setup_method(self):
+        self.rf = RequestFactory()
+        # Reset openapi state between tests
+        openapi.paths = {}
+        openapi.components = {"schemas": {}}
+        openapi.definitions = {}
+        openapi.tags = []
+
+    def test_generates_schema(self):
+        request = self.rf.get("/")
+        schema = openapi.dict(request, use_cache=False)
+        assert schema["openapi"] == "3.1.0"
+        assert "paths" in schema
+        assert "components" in schema
+        assert "info" in schema
+
+    def test_discovers_djapy_views(self):
+        request = self.rf.get("/")
+        schema = openapi.dict(request, use_cache=False)
+        assert len(schema["paths"]) > 0
+
+    def test_paths_have_methods(self):
+        request = self.rf.get("/")
+        schema = openapi.dict(request, use_cache=False)
+        for path_key, path_obj in schema["paths"].items():
+            methods = {"get", "post", "put", "patch", "delete", "options", "head"}
+            assert any(m in path_obj for m in methods), f"No method found in {path_key}"
+
+    def test_set_basic_info(self):
+        openapi.set_basic_info(
+            title="Test API",
+            description="A test API",
+            version="2.0.0",
+        )
+        assert openapi.info.title == "Test API"
+        assert openapi.info.version == "2.0.0"
+
+    def test_servers_include_request_url(self):
+        request = self.rf.get("/")
+        schema = openapi.dict(request, use_cache=False)
+        assert len(schema["servers"]) >= 1
+        assert "url" in schema["servers"][0]
+
+    def test_is_djapy_openapi_true(self):
+        class FakeView:
+            djapy = True
+            openapi = True
+        assert openapi.is_djapy_openapi(FakeView) is True
+
+    def test_is_djapy_openapi_false(self):
+        class FakeView:
+            djapy = False
+        assert openapi.is_djapy_openapi(FakeView) is False

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,133 @@
+import json
+import pytest
+
+from tests.testapp.models import Item
+
+
+@pytest.fixture
+def many_items(db):
+    return [Item.objects.create(title=f"Item {i}", price=i * 10) for i in range(25)]
+
+
+class TestOffsetLimitPagination:
+    def test_default_pagination(self, client, many_items):
+        response = client.get("/items/paginated/offset/")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert len(data["items"]) == 10
+        assert data["offset"] == 0
+        assert data["limit"] == 10
+        assert data["total"] == 25
+        assert data["has_next"] is True
+        assert data["has_previous"] is False
+        assert data["total_pages"] == 3
+
+    def test_second_page(self, client, many_items):
+        response = client.get("/items/paginated/offset/?offset=10&limit=10")
+        data = json.loads(response.content)
+        assert len(data["items"]) == 10
+        assert data["has_next"] is True
+        assert data["has_previous"] is True
+        assert data["current_page"] == 2
+
+    def test_last_page(self, client, many_items):
+        response = client.get("/items/paginated/offset/?offset=20&limit=10")
+        data = json.loads(response.content)
+        assert len(data["items"]) == 5
+        assert data["has_next"] is False
+        assert data["has_previous"] is True
+
+    def test_custom_limit(self, client, many_items):
+        response = client.get("/items/paginated/offset/?offset=0&limit=5")
+        data = json.loads(response.content)
+        assert len(data["items"]) == 5
+        assert data["total_pages"] == 5
+
+    def test_empty_results(self, client, db):
+        response = client.get("/items/paginated/offset/")
+        data = json.loads(response.content)
+        assert len(data["items"]) == 0
+        assert data["total"] == 0
+        assert data["total_pages"] == 0
+
+    def test_computed_fields(self, client, many_items):
+        response = client.get("/items/paginated/offset/?offset=5&limit=10")
+        data = json.loads(response.content)
+        assert data["start_index"] == 6
+        assert data["end_index"] == 15
+        assert data["items_count"] == 10
+
+
+class TestPageNumberPagination:
+    def test_first_page(self, client, many_items):
+        response = client.get("/items/paginated/page/")
+        data = json.loads(response.content)
+        assert response.status_code == 200
+        assert len(data["items"]) == 10
+        assert data["current_page"] == 1
+        assert data["has_next"] is True
+        assert data["has_previous"] is False
+        assert data["is_first_page"] is True
+
+    def test_second_page(self, client, many_items):
+        response = client.get("/items/paginated/page/?page_number=2&page_size=10")
+        data = json.loads(response.content)
+        assert data["current_page"] == 2
+        assert data["has_previous"] is True
+
+    def test_last_page(self, client, many_items):
+        response = client.get("/items/paginated/page/?page_number=3&page_size=10")
+        data = json.loads(response.content)
+        assert data["is_last_page"] is True
+        assert data["has_next"] is False
+        assert len(data["items"]) == 5
+
+    def test_beyond_last_page(self, client, many_items):
+        response = client.get("/items/paginated/page/?page_number=100&page_size=10")
+        data = json.loads(response.content)
+        assert len(data["items"]) == 0
+        assert data["has_next"] is False
+
+    def test_empty_queryset(self, client, db):
+        response = client.get("/items/paginated/page/")
+        data = json.loads(response.content)
+        assert data["total"] == 0
+        # Django's Paginator returns num_pages=1 for empty queryset
+        # (allow_empty_first_page=True by default)
+        assert data["num_pages"] == 1
+
+
+class TestCursorPagination:
+    def test_first_page_no_cursor(self, client, many_items):
+        response = client.get("/items/paginated/cursor/?limit=5")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert len(data["items"]) == 5
+        assert data["has_next"] is True
+        assert data["limit"] == 5
+
+    def test_cursor_forward(self, client, many_items):
+        resp1 = client.get("/items/paginated/cursor/?limit=5&ordering=asc")
+        data1 = json.loads(resp1.content)
+        cursor = data1["cursor"]
+        assert cursor is not None
+
+        resp2 = client.get(f"/items/paginated/cursor/?cursor={cursor}&limit=5&ordering=asc")
+        data2 = json.loads(resp2.content)
+        assert len(data2["items"]) == 5
+        # Items should be different (next page)
+        item_ids_1 = [i["id"] for i in data1["items"]]
+        item_ids_2 = [i["id"] for i in data2["items"]]
+        assert set(item_ids_1).isdisjoint(set(item_ids_2))
+
+    def test_desc_ordering(self, client, many_items):
+        response = client.get("/items/paginated/cursor/?limit=5&ordering=desc")
+        data = json.loads(response.content)
+        assert data["ordering"] == "desc"
+        assert len(data["items"]) == 5
+
+    def test_empty_queryset(self, client, db):
+        response = client.get("/items/paginated/cursor/?limit=5")
+        data = json.loads(response.content)
+        assert len(data["items"]) == 0
+        assert data["has_next"] is False

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,94 @@
+import json
+import pytest
+
+from tests.testapp.models import Item
+
+
+@pytest.fixture
+def items_fixture(db):
+    return [
+        Item.objects.create(title="Item X", price=10),
+        Item.objects.create(title="Item Y", price=20),
+    ]
+
+
+class TestJsonBodyParsing:
+    def test_parses_json_body(self, client, db):
+        response = client.post(
+            "/items/create/",
+            data=json.dumps({"title": "From JSON", "price": 10}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data["title"] == "From JSON"
+
+    def test_empty_json_body(self, client, db):
+        response = client.post(
+            "/items/create/",
+            data="",
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+
+class TestFormDataParsing:
+    def test_parses_form_data(self, client, db):
+        response = client.post(
+            "/items/form-create/",
+            data={"title": "From Form", "description": "desc"},
+        )
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data["title"] == "From Form"
+
+
+class TestQueryParamParsing:
+    def test_string_query_param(self, client, items_fixture):
+        response = client.get("/items/search/?q=Item")
+        assert response.status_code == 200
+
+    def test_bool_query_param(self, client, items_fixture):
+        response = client.get("/items/search/?q=X&active=false")
+        assert response.status_code == 200
+
+    def test_url_path_param(self, client, items_fixture):
+        item = items_fixture[0]
+        response = client.get(f"/items/{item.pk}/")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data["id"] == item.pk
+
+
+class TestParserTupleAnnotation:
+    def test_parse_dict_annotation(self):
+        from djapy.core.parser import parse_tuple_annotation
+        from djapy.schema.schema import Schema
+
+        class S(Schema):
+            x: int
+
+        result = parse_tuple_annotation({200: S})
+        assert result == {200: S}
+
+    def test_parse_single_type(self):
+        from djapy.core.parser import parse_tuple_annotation
+        from djapy.schema.schema import Schema
+
+        class S(Schema):
+            x: int
+
+        result = parse_tuple_annotation(S)
+        assert result == {200: S}
+
+    def test_prepare_schema_dict(self):
+        from djapy.core.parser import prepare_schema
+
+        result = prepare_schema({200: str, 404: str})
+        assert result == {200: str, 404: str}
+
+    def test_prepare_schema_single(self):
+        from djapy.core.parser import prepare_schema
+
+        result = prepare_schema(str)
+        assert result == {200: str}

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,73 @@
+from pydantic import ValidationError, BaseModel
+
+from djapy.core.response import (
+    create_json_from_validation_error,
+    create_validation_error,
+    format_error_response,
+)
+
+
+class StubModel(BaseModel):
+    name: str
+    age: int
+
+
+class TestCreateJsonFromValidationError:
+    def test_detailed_format(self):
+        try:
+            StubModel(name=123, age="not_int")
+        except ValidationError as e:
+            result = create_json_from_validation_error(e, detailed=True)
+
+        assert result["type"] == "validation_error"
+        assert result["error_count"] >= 1
+        assert "errors" in result
+        assert "title" in result
+
+    def test_simplified_format(self):
+        try:
+            StubModel(name=123, age="not_int")
+        except ValidationError as e:
+            result = create_json_from_validation_error(e, detailed=False)
+
+        assert result["type"] == "validation_error"
+        assert "errors" in result
+        for err in result["errors"]:
+            assert "field" in err
+            assert "message" in err
+            assert "type" in err
+
+
+class TestCreateValidationError:
+    def test_creates_validation_error(self):
+        exc = create_validation_error("TestTitle", "field_name", "missing")
+        assert isinstance(exc, ValidationError)
+        assert exc.error_count() == 1
+
+    def test_with_custom_message(self):
+        exc = create_validation_error("TestTitle", "email", "missing", msg="Invalid email")
+        assert isinstance(exc, ValidationError)
+        errors = exc.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("email",)
+
+
+class TestFormatErrorResponse:
+    def test_basic_error(self):
+        result = format_error_response("auth_error", "Not authenticated")
+        assert result == {
+            "type": "auth_error",
+            "message": "Not authenticated",
+            "status": 400,
+        }
+
+    def test_with_details(self):
+        result = format_error_response(
+            "validation_error", "Bad input", details={"field": "name"}, status_code=422
+        )
+        assert result["status"] == 422
+        assert result["details"] == {"field": "name"}
+
+    def test_without_details_no_key(self):
+        result = format_error_response("error", "msg")
+        assert "details" not in result

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,106 @@
+import pytest
+from pydantic import ValidationError
+
+from djapy.schema.schema import Schema, Form, QueryMapperSchema, Outsource, get_json_dict
+
+
+class TestSchema:
+    def test_is_empty_true(self):
+        EmptySchema = type("EmptySchema", (Schema,), {"__annotations__": {}})
+        assert EmptySchema.is_empty() is True
+
+    def test_is_empty_false(self):
+        class NonEmpty(Schema):
+            name: str
+        assert NonEmpty.is_empty() is False
+
+    def test_from_attributes(self):
+        class ItemSchema(Schema):
+            name: str
+            value: int
+
+        class FakeObj:
+            name = "test"
+            value = 42
+
+        result = ItemSchema.model_validate(FakeObj())
+        assert result.name == "test"
+        assert result.value == 42
+
+    def test_validate_via_request(self):
+        class SimpleSchema(Schema):
+            name: str
+
+        result = SimpleSchema.validate_via_request({"name": "hello"})
+        assert result.name == "hello"
+
+    def test_validate_via_request_invalid(self):
+        class SimpleSchema(Schema):
+            name: str
+
+        with pytest.raises(ValidationError):
+            SimpleSchema.validate_via_request({"wrong_key": "hello"})
+
+    def test_model_dump_fast(self):
+        class S(Schema):
+            x: int
+        obj = S(x=1)
+        assert obj.model_dump_fast() == {"x": 1}
+
+    def test_single_field_schema(self):
+        class Inner(Schema):
+            val: int
+
+        class Wrapper(Schema):
+            inner: Inner
+
+        result = Wrapper._single()
+        assert result is not None
+        assert result[0] == "inner"
+
+
+class TestForm:
+    def test_cvar_c_type(self):
+        assert Form.cvar_c_type == "application/x-www-form-urlencoded"
+
+    def test_querydict_list_to_single(self):
+        class MyForm(Form):
+            name: str
+            age: int
+
+        result = MyForm.model_validate({"name": ["John"], "age": ["25"]})
+        assert result.name == "John"
+        assert result.age == 25
+
+
+class TestQueryMapperSchema:
+    def test_querydict_list_conversion(self):
+        class QS(QueryMapperSchema):
+            search: str
+
+        result = QS.model_validate({"search": ["hello"]})
+        assert result.search == "hello"
+
+    def test_cvar_type(self):
+        assert QueryMapperSchema.cvar_c_type == "_query_mapper"
+
+
+class TestGetJsonDict:
+    def test_parses_json_string(self):
+        result = get_json_dict('{"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_nested_json(self):
+        result = get_json_dict('{"outer": {"inner": 1}}')
+        assert result == {"outer": {"inner": 1}}
+
+
+class TestOutsource:
+    def test_outsource_stores_original_object(self):
+        class OS(Outsource):
+            name: str
+
+        # Outsource inherits from BaseModel, so we use dict input
+        result = OS.model_validate({"name": "test"})
+        assert result._obj is not None
+        assert result.name == "test"

--- a/tests/test_type_check.py
+++ b/tests/test_type_check.py
@@ -1,0 +1,139 @@
+import inspect
+from typing import Annotated, Union, List, Optional
+
+from pydantic import BaseModel, Field
+
+from djapy.core.type_check import (
+    is_param_query_type,
+    is_base_query_type,
+    is_union_of_basic_types,
+    is_annotated_of_basic_types,
+    schema_type,
+    is_django_type,
+    is_data_type,
+    get_type_name,
+    basic_query_schema,
+)
+
+
+class SampleSchema(BaseModel):
+    name: str
+
+
+def _make_param(name: str, annotation, default=inspect.Parameter.empty):
+    return inspect.Parameter(name, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=annotation, default=default)
+
+
+class TestIsBaseQueryType:
+    def test_str(self):
+        assert is_base_query_type(str) is True
+
+    def test_int(self):
+        assert is_base_query_type(int) is True
+
+    def test_float(self):
+        assert is_base_query_type(float) is True
+
+    def test_bool(self):
+        assert is_base_query_type(bool) is True
+
+    def test_pydantic_model_not_query(self):
+        assert is_base_query_type(SampleSchema) is False
+
+    def test_list_is_query(self):
+        assert is_base_query_type(list) is True
+
+    def test_dict_not_query(self):
+        assert is_base_query_type(dict) is False
+
+
+class TestIsUnionOfBasicTypes:
+    def test_str_or_int(self):
+        assert is_union_of_basic_types(str | int) is True
+
+    def test_str_or_float_or_bool(self):
+        assert is_union_of_basic_types(str | float | bool) is True
+
+    def test_str_or_dict_not_basic(self):
+        assert is_union_of_basic_types(str | dict) is False
+
+    def test_plain_str_not_union(self):
+        assert is_union_of_basic_types(str) is False
+
+
+class TestIsAnnotatedOfBasicTypes:
+    def test_annotated_str_with_field(self):
+        ann = Annotated[str, Field(description="test")]
+        assert is_annotated_of_basic_types(ann) is True
+
+    def test_annotated_int(self):
+        ann = Annotated[int, Field(ge=0)]
+        assert is_annotated_of_basic_types(ann) is True
+
+    def test_annotated_model_not_basic(self):
+        ann = Annotated[SampleSchema, Field()]
+        assert is_annotated_of_basic_types(ann) is False
+
+    def test_plain_str_not_annotated(self):
+        assert is_annotated_of_basic_types(str) is False
+
+
+class TestIsParamQueryType:
+    def test_str_param(self):
+        param = _make_param("q", str)
+        assert is_param_query_type(param) is True
+
+    def test_int_param(self):
+        param = _make_param("pk", int)
+        assert is_param_query_type(param) is True
+
+    def test_schema_param_not_query(self):
+        param = _make_param("data", SampleSchema)
+        assert is_param_query_type(param) is False
+
+    def test_annotated_str_param(self):
+        param = _make_param("q", Annotated[str, Field()])
+        assert is_param_query_type(param) is True
+
+
+class TestSchemaType:
+    def test_pydantic_model(self):
+        assert schema_type(SampleSchema) == SampleSchema
+
+    def test_str_not_schema(self):
+        assert schema_type(str) is None
+
+    def test_param_with_model(self):
+        param = _make_param("data", SampleSchema)
+        assert schema_type(param) == SampleSchema
+
+    def test_param_with_str(self):
+        param = _make_param("q", str)
+        assert schema_type(param) is None
+
+
+class TestGetTypeName:
+    def test_str(self):
+        assert get_type_name(str) == "str"
+
+    def test_int(self):
+        assert get_type_name(int) == "int"
+
+    def test_bool(self):
+        assert get_type_name(bool) == "bool"
+
+
+class TestBasicQuerySchema:
+    def test_str_param(self):
+        param = _make_param("q", str)
+        result = basic_query_schema(param)
+        assert result == {"type": "string"}
+
+    def test_int_param(self):
+        param = _make_param("pk", int)
+        result = basic_query_schema(param)
+        assert result == {"type": "integer"}
+
+    def test_string_slug(self):
+        result = basic_query_schema("slug")
+        assert result == {"type": "string"}

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,0 +1,26 @@
+from django.db import models
+
+
+class Tag(models.Model):
+    name = models.CharField(max_length=50, unique=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self):
+        return self.name
+
+
+class Item(models.Model):
+    title = models.CharField(max_length=200)
+    description = models.TextField(blank=True, default="")
+    price = models.DecimalField(max_digits=10, decimal_places=2, default=0)
+    is_active = models.BooleanField(default=True)
+    tags = models.ManyToManyField(Tag, blank=True, related_name="items")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return self.title

--- a/tests/testapp/schemas.py
+++ b/tests/testapp/schemas.py
@@ -1,0 +1,47 @@
+from pydantic import computed_field, Field
+from djapy.schema import Schema, Form
+from djapy.schema.schema import QueryList, Outsource
+
+
+class TagSchema(Schema):
+    id: int
+    name: str
+
+
+class ItemSchema(Schema):
+    id: int
+    title: str
+    description: str
+    price: float
+    is_active: bool
+
+
+class ItemDetailSchema(Outsource):
+    id: int
+    title: str
+    description: str
+    price: float
+    is_active: bool
+    tags: QueryList[TagSchema]
+
+    @computed_field
+    @property
+    def tag_count(self) -> int:
+        return len(self.tags)
+
+
+class ItemCreateSchema(Schema):
+    title: str
+    description: str = ""
+    price: float = Field(gt=0)
+    is_active: bool = True
+
+
+class ItemFormSchema(Form):
+    title: str
+    description: str = ""
+
+
+class ErrorSchema(Schema):
+    message: str
+    alias: str = "error"

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,0 +1,20 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("items/", views.list_items, name="list-items"),
+    path("items/create/", views.create_item, name="create-item"),
+    path("items/<int:pk>/", views.get_item, name="get-item"),
+    path("items/search/", views.search_items, name="search-items"),
+    path("items/protected/", views.protected_view, name="protected"),
+    path("items/permission/", views.permission_view, name="permission"),
+    path("items/public/", views.no_auth_view, name="public"),
+    path("items/async/", views.async_list_items, name="async-list"),
+    path("items/paginated/offset/", views.paginated_items_offset, name="paginated-offset"),
+    path("items/paginated/page/", views.paginated_items_page, name="paginated-page"),
+    path("items/paginated/cursor/", views.paginated_items_cursor, name="paginated-cursor"),
+    path("items/form-create/", views.form_create_item, name="form-create"),
+    path("items/multi-method/", views.multi_method_view, name="multi-method"),
+    path("items/json-response/", views.json_response_view, name="json-response"),
+    path("items/status-code/", views.status_code_view, name="status-code"),
+]

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -1,0 +1,103 @@
+from django.http import HttpRequest, JsonResponse
+from djapy import djapify, async_djapify
+from djapy.core.auth import djapy_auth, SessionAuth
+from djapy.pagination import OffsetLimitPagination, PageNumberPagination, CursorPagination
+from djapy.pagination.dec import paginate
+
+from .models import Item
+from .schemas import (
+    ItemSchema, ItemDetailSchema, ItemCreateSchema,
+    ItemFormSchema, ErrorSchema,
+)
+
+
+@djapify
+def list_items(request: HttpRequest) -> {200: list[ItemSchema]}:
+    return 200, Item.objects.all()
+
+
+@djapify(method="POST")
+def create_item(request: HttpRequest, data: ItemCreateSchema) -> {200: ItemSchema, 400: ErrorSchema}:
+    item = Item.objects.create(**data.model_dump())
+    return 200, item
+
+
+@djapify
+def get_item(request: HttpRequest, pk: int) -> {200: ItemDetailSchema, 404: ErrorSchema}:
+    try:
+        item = Item.objects.get(pk=pk)
+    except Item.DoesNotExist:
+        return 404, {"message": "Item not found", "alias": "not_found"}
+    return 200, item
+
+
+@djapify(method="GET")
+def search_items(request: HttpRequest, q: str, active: bool = True) -> {200: list[ItemSchema]}:
+    qs = Item.objects.filter(title__icontains=q, is_active=active)
+    return 200, qs
+
+
+@djapify
+@djapy_auth(SessionAuth)
+def protected_view(request: HttpRequest) -> {200: list[ItemSchema]}:
+    return 200, Item.objects.all()
+
+
+@djapify
+@djapy_auth(SessionAuth, permissions=["testapp.add_item"])
+def permission_view(request: HttpRequest) -> {200: list[ItemSchema]}:
+    return 200, Item.objects.all()
+
+
+@djapify
+def no_auth_view(request: HttpRequest) -> {200: list[ItemSchema]}:
+    return 200, Item.objects.all()
+
+
+@async_djapify
+async def async_list_items(request: HttpRequest) -> {200: list[ItemSchema]}:
+    from asgiref.sync import sync_to_async
+    items = await sync_to_async(list)(Item.objects.all())
+    return 200, items
+
+
+@djapify
+@paginate(OffsetLimitPagination)
+def paginated_items_offset(request: HttpRequest) -> {200: list[ItemSchema]}:
+    return 200, Item.objects.all()
+
+
+@djapify
+@paginate(PageNumberPagination)
+def paginated_items_page(request: HttpRequest) -> {200: list[ItemSchema]}:
+    return 200, Item.objects.all()
+
+
+@djapify
+@paginate(CursorPagination)
+def paginated_items_cursor(request: HttpRequest) -> {200: list[ItemSchema]}:
+    return 200, Item.objects.all()
+
+
+@djapify(method="POST")
+def form_create_item(request: HttpRequest, data: ItemFormSchema) -> {200: ItemSchema}:
+    item = Item.objects.create(title=data.title, description=data.description)
+    return 200, item
+
+
+@djapify(method=["GET", "POST"])
+def multi_method_view(request: HttpRequest) -> {200: list[ItemSchema]}:
+    return 200, Item.objects.all()
+
+
+@djapify
+def json_response_view(request: HttpRequest) -> {200: ItemSchema}:
+    return JsonResponse({"custom": "response"})
+
+
+@djapify(method="POST")
+def status_code_view(request: HttpRequest, fail: bool = False) -> {200: ItemSchema, 400: ErrorSchema}:
+    if fail:
+        return 400, {"message": "Intentional failure", "alias": "bad_request"}
+    item = Item.objects.first()
+    return 200, item

--- a/uv.lock
+++ b/uv.lock
@@ -24,40 +24,209 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/d4/7827d9ffa34d5d4d752eec907022aa417120936282fc488306f5da08c292/coverage-7.13.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0fc31c787a84f8cd6027eba44010517020e0d18487064cd3d8968941856d1415", size = 219152, upload-time = "2026-02-09T12:56:11.974Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b0/d69df26607c64043292644dbb9dc54b0856fabaa2cbb1eeee3331cc9e280/coverage-7.13.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a32ebc02a1805adf637fc8dec324b5cdacd2e493515424f70ee33799573d661b", size = 219667, upload-time = "2026-02-09T12:56:13.33Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a4/c1523f7c9e47b2271dbf8c2a097e7a1f89ef0d66f5840bb59b7e8814157b/coverage-7.13.4-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e24f9156097ff9dc286f2f913df3a7f63c0e333dcafa3c196f2c18b4175ca09a", size = 246425, upload-time = "2026-02-09T12:56:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/02/aa7ec01d1a5023c4b680ab7257f9bfde9defe8fdddfe40be096ac19e8177/coverage-7.13.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8041b6c5bfdc03257666e9881d33b1abc88daccaf73f7b6340fb7946655cd10f", size = 248229, upload-time = "2026-02-09T12:56:16.31Z" },
+    { url = "https://files.pythonhosted.org/packages/35/98/85aba0aed5126d896162087ef3f0e789a225697245256fc6181b95f47207/coverage-7.13.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a09cfa6a5862bc2fc6ca7c3def5b2926194a56b8ab78ffcf617d28911123012", size = 250106, upload-time = "2026-02-09T12:56:18.024Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1db59bd67494bc162e3e4cd5fbc7edba2c7026b22f7c8ef1496d58c2b94c/coverage-7.13.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:296f8b0af861d3970c2a4d8c91d48eb4dd4771bcef9baedec6a9b515d7de3def", size = 252021, upload-time = "2026-02-09T12:56:19.272Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/97/72899c59c7066961de6e3daa142d459d47d104956db43e057e034f015c8a/coverage-7.13.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e101609bcbbfb04605ea1027b10dc3735c094d12d40826a60f897b98b1c30256", size = 247114, upload-time = "2026-02-09T12:56:21.051Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1f/f1885573b5970235e908da4389176936c8933e86cb316b9620aab1585fa2/coverage-7.13.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa3feb8db2e87ff5e6d00d7e1480ae241876286691265657b500886c98f38bda", size = 248143, upload-time = "2026-02-09T12:56:22.585Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/cf/e80390c5b7480b722fa3e994f8202807799b85bc562aa4f1dde209fbb7be/coverage-7.13.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4fc7fa81bbaf5a02801b65346c8b3e657f1d93763e58c0abdf7c992addd81a92", size = 246152, upload-time = "2026-02-09T12:56:23.748Z" },
+    { url = "https://files.pythonhosted.org/packages/44/bf/f89a8350d85572f95412debb0fb9bb4795b1d5b5232bd652923c759e787b/coverage-7.13.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:33901f604424145c6e9c2398684b92e176c0b12df77d52db81c20abd48c3794c", size = 249959, upload-time = "2026-02-09T12:56:25.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/6e/612a02aece8178c818df273e8d1642190c4875402ca2ba74514394b27aba/coverage-7.13.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:bb28c0f2cf2782508a40cec377935829d5fcc3ad9a3681375af4e84eb34b6b58", size = 246416, upload-time = "2026-02-09T12:56:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/98/b5afc39af67c2fa6786b03c3a7091fc300947387ce8914b096db8a73d67a/coverage-7.13.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d107aff57a83222ddbd8d9ee705ede2af2cc926608b57abed8ef96b50b7e8f9", size = 247025, upload-time = "2026-02-09T12:56:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/51/30/2bba8ef0682d5bd210c38fe497e12a06c9f8d663f7025e9f5c2c31ce847d/coverage-7.13.4-cp310-cp310-win32.whl", hash = "sha256:a6f94a7d00eb18f1b6d403c91a88fd58cfc92d4b16080dfdb774afc8294469bf", size = 221758, upload-time = "2026-02-09T12:56:29.051Z" },
+    { url = "https://files.pythonhosted.org/packages/78/13/331f94934cf6c092b8ea59ff868eb587bc8fe0893f02c55bc6c0183a192e/coverage-7.13.4-cp310-cp310-win_amd64.whl", hash = "sha256:2cb0f1e000ebc419632bbe04366a8990b6e32c4e0b51543a6484ffe15eaeda95", size = 222693, upload-time = "2026-02-09T12:56:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ad/b59e5b451cf7172b8d1043dc0fa718f23aab379bc1521ee13d4bd9bfa960/coverage-7.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d490ba50c3f35dd7c17953c68f3270e7ccd1c6642e2d2afe2d8e720b98f5a053", size = 219278, upload-time = "2026-02-09T12:56:31.673Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/17/0cb7ca3de72e5f4ef2ec2fa0089beafbcaaaead1844e8b8a63d35173d77d/coverage-7.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:19bc3c88078789f8ef36acb014d7241961dbf883fd2533d18cb1e7a5b4e28b11", size = 219783, upload-time = "2026-02-09T12:56:33.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/63/325d8e5b11e0eaf6d0f6a44fad444ae58820929a9b0de943fa377fe73e85/coverage-7.13.4-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3998e5a32e62fdf410c0dbd3115df86297995d6e3429af80b8798aad894ca7aa", size = 250200, upload-time = "2026-02-09T12:56:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/76/53/c16972708cbb79f2942922571a687c52bd109a7bd51175aeb7558dff2236/coverage-7.13.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e264226ec98e01a8e1054314af91ee6cde0eacac4f465cc93b03dbe0bce2fd7", size = 252114, upload-time = "2026-02-09T12:56:35.749Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c2/7ab36d8b8cc412bec9ea2d07c83c48930eb4ba649634ba00cb7e4e0f9017/coverage-7.13.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3aa4e7b9e416774b21797365b358a6e827ffadaaca81b69ee02946852449f00", size = 254220, upload-time = "2026-02-09T12:56:37.796Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/4d/cf52c9a3322c89a0e6febdfbc83bb45c0ed3c64ad14081b9503adee702e7/coverage-7.13.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:71ca20079dd8f27fcf808817e281e90220475cd75115162218d0e27549f95fef", size = 256164, upload-time = "2026-02-09T12:56:39.016Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e9/eb1dd17bd6de8289df3580e967e78294f352a5df8a57ff4671ee5fc3dcd0/coverage-7.13.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e2f25215f1a359ab17320b47bcdaca3e6e6356652e8256f2441e4ef972052903", size = 250325, upload-time = "2026-02-09T12:56:40.668Z" },
+    { url = "https://files.pythonhosted.org/packages/71/07/8c1542aa873728f72267c07278c5cc0ec91356daf974df21335ccdb46368/coverage-7.13.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d65b2d373032411e86960604dc4edac91fdfb5dca539461cf2cbe78327d1e64f", size = 251913, upload-time = "2026-02-09T12:56:41.97Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d7/c62e2c5e4483a748e27868e4c32ad3daa9bdddbba58e1bc7a15e252baa74/coverage-7.13.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94eb63f9b363180aff17de3e7c8760c3ba94664ea2695c52f10111244d16a299", size = 249974, upload-time = "2026-02-09T12:56:43.323Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9f/4c5c015a6e98ced54efd0f5cf8d31b88e5504ecb6857585fc0161bb1e600/coverage-7.13.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e856bf6616714c3a9fbc270ab54103f4e685ba236fa98c054e8f87f266c93505", size = 253741, upload-time = "2026-02-09T12:56:45.155Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/59/0f4eef89b9f0fcd9633b5d350016f54126ab49426a70ff4c4e87446cabdc/coverage-7.13.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:65dfcbe305c3dfe658492df2d85259e0d79ead4177f9ae724b6fb245198f55d6", size = 249695, upload-time = "2026-02-09T12:56:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2c/b7476f938deb07166f3eb281a385c262675d688ff4659ad56c6c6b8e2e70/coverage-7.13.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b507778ae8a4c915436ed5c2e05b4a6cecfa70f734e19c22a005152a11c7b6a9", size = 250599, upload-time = "2026-02-09T12:56:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/34/c3420709d9846ee3785b9f2831b4d94f276f38884032dca1457fa83f7476/coverage-7.13.4-cp311-cp311-win32.whl", hash = "sha256:784fc3cf8be001197b652d51d3fd259b1e2262888693a4636e18879f613a62a9", size = 221780, upload-time = "2026-02-09T12:56:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/61/08/3d9c8613079d2b11c185b865de9a4c1a68850cfda2b357fae365cf609f29/coverage-7.13.4-cp311-cp311-win_amd64.whl", hash = "sha256:2421d591f8ca05b308cf0092807308b2facbefe54af7c02ac22548b88b95c98f", size = 222715, upload-time = "2026-02-09T12:56:51.815Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1a/54c3c80b2f056164cc0a6cdcb040733760c7c4be9d780fe655f356f433e4/coverage-7.13.4-cp311-cp311-win_arm64.whl", hash = "sha256:79e73a76b854d9c6088fe5d8b2ebe745f8681c55f7397c3c0a016192d681045f", size = 221385, upload-time = "2026-02-09T12:56:53.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/81/4ce2fdd909c5a0ed1f6dedb88aa57ab79b6d1fbd9b588c1ac7ef45659566/coverage-7.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02231499b08dabbe2b96612993e5fc34217cdae907a51b906ac7fca8027a4459", size = 219449, upload-time = "2026-02-09T12:56:54.889Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/96/5238b1efc5922ddbdc9b0db9243152c09777804fb7c02ad1741eb18a11c0/coverage-7.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40aa8808140e55dc022b15d8aa7f651b6b3d68b365ea0398f1441e0b04d859c3", size = 219810, upload-time = "2026-02-09T12:56:56.33Z" },
+    { url = "https://files.pythonhosted.org/packages/78/72/2f372b726d433c9c35e56377cf1d513b4c16fe51841060d826b95caacec1/coverage-7.13.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5b856a8ccf749480024ff3bd7310adaef57bf31fd17e1bfc404b7940b6986634", size = 251308, upload-time = "2026-02-09T12:56:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/2ea570925524ef4e00bb6c82649f5682a77fac5ab910a65c9284de422600/coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c048ea43875fbf8b45d476ad79f179809c590ec7b79e2035c662e7afa3192e3", size = 254052, upload-time = "2026-02-09T12:56:59.754Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ac/45dc2e19a1939098d783c846e130b8f862fbb50d09e0af663988f2f21973/coverage-7.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7b38448866e83176e28086674fe7368ab8590e4610fb662b44e345b86d63ffa", size = 255165, upload-time = "2026-02-09T12:57:01.287Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4d/26d236ff35abc3b5e63540d3386e4c3b192168c1d96da5cb2f43c640970f/coverage-7.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:de6defc1c9badbf8b9e67ae90fd00519186d6ab64e5cc5f3d21359c2a9b2c1d3", size = 257432, upload-time = "2026-02-09T12:57:02.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/55/14a966c757d1348b2e19caf699415a2a4c4f7feaa4bbc6326a51f5c7dd1b/coverage-7.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7eda778067ad7ffccd23ecffce537dface96212576a07924cbf0d8799d2ded5a", size = 251716, upload-time = "2026-02-09T12:57:04.056Z" },
+    { url = "https://files.pythonhosted.org/packages/77/33/50116647905837c66d28b2af1321b845d5f5d19be9655cb84d4a0ea806b4/coverage-7.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e87f6c587c3f34356c3759f0420693e35e7eb0e2e41e4c011cb6ec6ecbbf1db7", size = 253089, upload-time = "2026-02-09T12:57:05.503Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/8efb11a46e3665d92635a56e4f2d4529de6d33f2cb38afd47d779d15fc99/coverage-7.13.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8248977c2e33aecb2ced42fef99f2d319e9904a36e55a8a68b69207fb7e43edc", size = 251232, upload-time = "2026-02-09T12:57:06.879Z" },
+    { url = "https://files.pythonhosted.org/packages/51/24/8cd73dd399b812cc76bb0ac260e671c4163093441847ffe058ac9fda1e32/coverage-7.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:25381386e80ae727608e662474db537d4df1ecd42379b5ba33c84633a2b36d47", size = 255299, upload-time = "2026-02-09T12:57:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/03/94/0a4b12f1d0e029ce1ccc1c800944a9984cbe7d678e470bb6d3c6bc38a0da/coverage-7.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ee756f00726693e5ba94d6df2bdfd64d4852d23b09bb0bc700e3b30e6f333985", size = 250796, upload-time = "2026-02-09T12:57:10.142Z" },
+    { url = "https://files.pythonhosted.org/packages/73/44/6002fbf88f6698ca034360ce474c406be6d5a985b3fdb3401128031eef6b/coverage-7.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fdfc1e28e7c7cdce44985b3043bc13bbd9c747520f94a4d7164af8260b3d91f0", size = 252673, upload-time = "2026-02-09T12:57:12.197Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c6/a0279f7c00e786be75a749a5674e6fa267bcbd8209cd10c9a450c655dfa7/coverage-7.13.4-cp312-cp312-win32.whl", hash = "sha256:01d4cbc3c283a17fc1e42d614a119f7f438eabb593391283adca8dc86eff1246", size = 221990, upload-time = "2026-02-09T12:57:14.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4e/c0a25a425fcf5557d9abd18419c95b63922e897bc86c1f327f155ef234a9/coverage-7.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:9401ebc7ef522f01d01d45532c68c5ac40fb27113019b6b7d8b208f6e9baa126", size = 222800, upload-time = "2026-02-09T12:57:15.944Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ac/92da44ad9a6f4e3a7debd178949d6f3769bedca33830ce9b1dcdab589a37/coverage-7.13.4-cp312-cp312-win_arm64.whl", hash = "sha256:b1ec7b6b6e93255f952e27ab58fbc68dcc468844b16ecbee881aeb29b6ab4d8d", size = 221415, upload-time = "2026-02-09T12:57:17.497Z" },
+    { url = "https://files.pythonhosted.org/packages/db/23/aad45061a31677d68e47499197a131eea55da4875d16c1f42021ab963503/coverage-7.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9", size = 219474, upload-time = "2026-02-09T12:57:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/70/9b8b67a0945f3dfec1fd896c5cefb7c19d5a3a6d74630b99a895170999ae/coverage-7.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac", size = 219844, upload-time = "2026-02-09T12:57:20.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/fd/7e859f8fab324cef6c4ad7cff156ca7c489fef9179d5749b0c8d321281c2/coverage-7.13.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea", size = 250832, upload-time = "2026-02-09T12:57:22.007Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/dc/b2442d10020c2f52617828862d8b6ee337859cd8f3a1f13d607dddda9cf7/coverage-7.13.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b", size = 253434, upload-time = "2026-02-09T12:57:23.339Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/88/6728a7ad17428b18d836540630487231f5470fb82454871149502f5e5aa2/coverage-7.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525", size = 254676, upload-time = "2026-02-09T12:57:24.774Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/bc/21244b1b8cedf0dff0a2b53b208015fe798d5f2a8d5348dbfece04224fff/coverage-7.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242", size = 256807, upload-time = "2026-02-09T12:57:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a0/ddba7ed3251cff51006737a727d84e05b61517d1784a9988a846ba508877/coverage-7.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148", size = 251058, upload-time = "2026-02-09T12:57:27.614Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/55/e289addf7ff54d3a540526f33751951bf0878f3809b47f6dfb3def69c6f7/coverage-7.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a", size = 252805, upload-time = "2026-02-09T12:57:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/cc276b1fa4a59be56d96f1dabddbdc30f4ba22e3b1cd42504c37b3313255/coverage-7.13.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23", size = 250766, upload-time = "2026-02-09T12:57:30.522Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/1093b8f93018f8b41a8cf29636c9292502f05e4a113d4d107d14a3acd044/coverage-7.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80", size = 254923, upload-time = "2026-02-09T12:57:31.946Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/55/ea2796da2d42257f37dbea1aab239ba9263b31bd91d5527cdd6db5efe174/coverage-7.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea", size = 250591, upload-time = "2026-02-09T12:57:33.842Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/7c4bb72aacf8af5020675aa633e59c1fbe296d22aed191b6a5b711eb2bc7/coverage-7.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a", size = 252364, upload-time = "2026-02-09T12:57:35.743Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/38/a8d2ec0146479c20bbaa7181b5b455a0c41101eed57f10dd19a78ab44c80/coverage-7.13.4-cp313-cp313-win32.whl", hash = "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d", size = 222010, upload-time = "2026-02-09T12:57:37.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/0c/dbfafbe90a185943dcfbc766fe0e1909f658811492d79b741523a414a6cc/coverage-7.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd", size = 222818, upload-time = "2026-02-09T12:57:38.734Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d1/934918a138c932c90d78301f45f677fb05c39a3112b96fd2c8e60503cdc7/coverage-7.13.4-cp313-cp313-win_arm64.whl", hash = "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af", size = 221438, upload-time = "2026-02-09T12:57:40.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/57/ee93ced533bcb3e6df961c0c6e42da2fc6addae53fb95b94a89b1e33ebd7/coverage-7.13.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d", size = 220165, upload-time = "2026-02-09T12:57:41.639Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/969fc285a6fbdda49d91af278488d904dcd7651b2693872f0ff94e40e84a/coverage-7.13.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12", size = 220516, upload-time = "2026-02-09T12:57:44.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b8/9531944e16267e2735a30a9641ff49671f07e8138ecf1ca13db9fd2560c7/coverage-7.13.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b", size = 261804, upload-time = "2026-02-09T12:57:45.989Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f3/e63df6d500314a2a60390d1989240d5f27318a7a68fa30ad3806e2a9323e/coverage-7.13.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9", size = 263885, upload-time = "2026-02-09T12:57:47.42Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/67/7654810de580e14b37670b60a09c599fa348e48312db5b216d730857ffe6/coverage-7.13.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092", size = 266308, upload-time = "2026-02-09T12:57:49.345Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/39d41eca0eab3cc82115953ad41c4e77935286c930e8fad15eaed1389d83/coverage-7.13.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9", size = 267452, upload-time = "2026-02-09T12:57:50.811Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6d/39c0fbb8fc5cd4d2090811e553c2108cf5112e882f82505ee7495349a6bf/coverage-7.13.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26", size = 261057, upload-time = "2026-02-09T12:57:52.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a2/60010c669df5fa603bb5a97fb75407e191a846510da70ac657eb696b7fce/coverage-7.13.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2", size = 263875, upload-time = "2026-02-09T12:57:53.938Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/63b22a6bdbd17f1f96e9ed58604c2a6b0e72a9133e37d663bef185877cf6/coverage-7.13.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940", size = 261500, upload-time = "2026-02-09T12:57:56.012Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bf/69f86ba1ad85bc3ad240e4c0e57a2e620fbc0e1645a47b5c62f0e941ad7f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c", size = 265212, upload-time = "2026-02-09T12:57:57.5Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f2/5f65a278a8c2148731831574c73e42f57204243d33bedaaf18fa79c5958f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0", size = 260398, upload-time = "2026-02-09T12:57:59.027Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/80/6e8280a350ee9fea92f14b8357448a242dcaa243cb2c72ab0ca591f66c8c/coverage-7.13.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b", size = 262584, upload-time = "2026-02-09T12:58:01.129Z" },
+    { url = "https://files.pythonhosted.org/packages/22/63/01ff182fc95f260b539590fb12c11ad3e21332c15f9799cb5e2386f71d9f/coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9", size = 222688, upload-time = "2026-02-09T12:58:02.736Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/43/89de4ef5d3cd53b886afa114065f7e9d3707bdb3e5efae13535b46ae483d/coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd", size = 223746, upload-time = "2026-02-09T12:58:05.362Z" },
+    { url = "https://files.pythonhosted.org/packages/35/39/7cf0aa9a10d470a5309b38b289b9bb07ddeac5d61af9b664fe9775a4cb3e/coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997", size = 222003, upload-time = "2026-02-09T12:58:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522, upload-time = "2026-02-09T12:58:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855, upload-time = "2026-02-09T12:58:10.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887, upload-time = "2026-02-09T12:58:12.503Z" },
+    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396, upload-time = "2026-02-09T12:58:14.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745, upload-time = "2026-02-09T12:58:16.162Z" },
+    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055, upload-time = "2026-02-09T12:58:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911, upload-time = "2026-02-09T12:58:19.495Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754, upload-time = "2026-02-09T12:58:21.064Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720, upload-time = "2026-02-09T12:58:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994, upload-time = "2026-02-09T12:58:24.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531, upload-time = "2026-02-09T12:58:26.271Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189, upload-time = "2026-02-09T12:58:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258, upload-time = "2026-02-09T12:58:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073, upload-time = "2026-02-09T12:58:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638, upload-time = "2026-02-09T12:58:32.599Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246, upload-time = "2026-02-09T12:58:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514, upload-time = "2026-02-09T12:58:35.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877, upload-time = "2026-02-09T12:58:37.864Z" },
+    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004, upload-time = "2026-02-09T12:58:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408, upload-time = "2026-02-09T12:58:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544, upload-time = "2026-02-09T12:58:44.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980, upload-time = "2026-02-09T12:58:45.721Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871, upload-time = "2026-02-09T12:58:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472, upload-time = "2026-02-09T12:58:48.995Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210, upload-time = "2026-02-09T12:58:51.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319, upload-time = "2026-02-09T12:58:53.081Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638, upload-time = "2026-02-09T12:58:55.258Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040, upload-time = "2026-02-09T12:58:56.936Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "django"
-version = "5.2.5"
+version = "5.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/9b/779f853c3d2d58b9e08346061ff3e331cdec3fe3f53aae509e256412a593/django-5.2.5.tar.gz", hash = "sha256:0745b25681b129a77aae3d4f6549b62d3913d74407831abaa0d9021a03954bae", size = 10859748, upload-time = "2025-08-06T08:26:29.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/45/1ac68964193cfcc0b0912a0f68025d5bdb54f71ba7b8716e85b959874bd0/django-5.1.15.tar.gz", hash = "sha256:46a356b5ff867bece73fc6365e081f21c569973403ee7e9b9a0316f27d0eb947", size = 10719662, upload-time = "2025-12-02T14:01:31.931Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/6e/98a1d23648e0085bb5825326af17612ecd8fc76be0ce96ea4dc35e17b926/django-5.2.5-py3-none-any.whl", hash = "sha256:2b2ada0ee8a5ff743a40e2b9820d1f8e24c11bac9ae6469cd548f0057ea6ddcd", size = 8302999, upload-time = "2025-08-06T08:26:23.562Z" },
+    { url = "https://files.pythonhosted.org/packages/27/79/372e091f0eba4ddb8228245ccd1baaa140e9658711f5e3a0056e540b4c1e/django-5.1.15-py3-none-any.whl", hash = "sha256:117871e58d6eda37f09870b7d73a3d66567b03aecd515b386b1751177c413432", size = 8260901, upload-time = "2025-12-02T14:01:27.352Z" },
 ]
 
 [[package]]
 name = "djapy"
-version = "0.3.1.dev0"
+version = "0.3.1.dev1"
 source = { editable = "." }
 dependencies = [
+    { name = "asgiref" },
     { name = "django" },
     { name = "pydantic" },
 ]
 
 [package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-django" },
+]
 performance = [
     { name = "orjson" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "django" },
+    { name = "asgiref", specifier = ">=3.7.0" },
+    { name = "django", specifier = ">=4.2,<5.2" },
     { name = "orjson", marker = "extra == 'performance'", specifier = ">=3.9.0" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "pytest-django", marker = "extra == 'dev'", specifier = ">=4.8" },
 ]
-provides-extras = ["performance"]
+provides-extras = ["performance", "dev"]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
 
 [[package]]
 name = "orjson"
@@ -134,6 +303,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/09/17d9d2b60592890ff7382e591aa1d9afb202a266b180c3d4049b1ec70e4a/orjson-3.11.3-cp314-cp314-win32.whl", hash = "sha256:0c6d7328c200c349e3a4c6d8c83e0a5ad029bdc2d417f234152bf34842d0fc8d", size = 136266, upload-time = "2025-08-26T17:46:13.853Z" },
     { url = "https://files.pythonhosted.org/packages/15/58/358f6846410a6b4958b74734727e582ed971e13d335d6c7ce3e47730493e/orjson-3.11.3-cp314-cp314-win_amd64.whl", hash = "sha256:317bbe2c069bbc757b1a2e4105b64aacd3bc78279b66a6b9e51e846e4809f804", size = 131351, upload-time = "2025-08-26T17:46:15.27Z" },
     { url = "https://files.pythonhosted.org/packages/28/01/d6b274a0635be0468d4dbd9cafe80c47105937a0d42434e805e67cd2ed8b/orjson-3.11.3-cp314-cp314-win_arm64.whl", hash = "sha256:e8f6a7a27d7b7bec81bd5924163e9af03d49bbb63013f107b48eb5d16db711bc", size = 125985, upload-time = "2025-08-26T17:46:16.67Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -239,12 +426,133 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-django"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/2b/db9a193df89e5660137f5428063bcc2ced7ad790003b26974adf5c5ceb3b/pytest_django-4.12.0.tar.gz", hash = "sha256:df94ec819a83c8979c8f6de13d9cdfbe76e8c21d39473cfe2b40c9fc9be3c758", size = 91156, upload-time = "2026-02-14T18:40:49.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/a5/41d091f697c09609e7ef1d5d61925494e0454ebf51de7de05f0f0a728f1d/pytest_django-4.12.0-py3-none-any.whl", hash = "sha256:3ff300c49f8350ba2953b90297d23bf5f589db69545f56f1ec5f8cff5da83e85", size = 26123, upload-time = "2026-02-14T18:40:47.381Z" },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999, upload-time = "2024-12-10T12:05:30.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415, upload-time = "2024-12-10T12:05:27.824Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **CI/CD:** GitHub Actions pipeline with ruff lint, test matrix (Python 3.10/3.12/3.13 × Django 4.2/5.0/5.1), and coverage gate (60% min)
- **Test suite:** 122 tests across 10 test files covering decorators, auth, pagination, schemas, parsers, middleware, OpenAPI, error handling, type checking, and response serialization — achieving 84% coverage
- **Dependency fixes:** Pin Django >=4.2,<5.2, add explicit asgiref dependency, add dev dependency group
- **5 bug fixes** discovered during testing:
  1. `Outsource` inherited `BaseModel` instead of `Schema`, missing `from_attributes=True` — broke Django model validation
  2. `djapy_auth(msg=None)` clobbered the default auth error message with `None`
  3. `check_access` called `authenticate()` but never `authorize()` — permission checking was non-functional
  4. Empty JSON request body caused 500 (TypeError) instead of 400 (ValidationError)
  5. Pydantic V2 deprecation: `.dict()` → `.model_dump()` in `get_json_dict`

## Test plan

- [ ] CI pipeline passes lint job (ruff check)
- [ ] All 9 matrix jobs pass (3 Python × 3 Django versions)
- [ ] Coverage job confirms ≥60% (currently 84%)
- [ ] Auth tests verify both `authenticate()` and `authorize()` paths
- [ ] Empty body test confirms 400 instead of 500
- [ ] Outsource schema validates Django model instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)